### PR TITLE
Fixed exports of package.json for commonjs use.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,24 +41,54 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./seiName": {
-      "types": "./dist/seiName.d.ts",
-      "default": "./dist/seiName.js"
+      "import": {
+        "types": "./dist/seiName.d.ts",
+        "default": "./dist/seiName.js"
+      },
+      "require": {
+        "types": "./dist/seiName.d.cts",
+        "default": "./dist/seiName.cjs"
+      }
     },
     "./injName": {
-      "types": "./dist/injName.d.ts",
-      "default": "./dist/injName.js"
+      "import": {
+        "types": "./dist/injName.d.ts",
+        "default": "./dist/injName.js"
+      },
+      "require": {
+        "types": "./dist/injName.d.cts",
+        "default": "./dist/injName.cjs"
+      }
     },
     "./solName": {
-      "types": "./dist/solName.d.ts",
-      "default": "./dist/solName.js"
+      "import": {
+        "types": "./dist/solName.d.ts",
+        "default": "./dist/solName.js"
+      },
+      "require": {
+        "types": "./dist/solName.d.cts",
+        "default": "./dist/solName.cjs"
+      }
     },
     "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.js"
+      "import": {
+        "types": "./dist/utils/index.d.ts",
+        "default": "./dist/utils/index.js"
+      },
+      "require": {
+        "types": "./dist/utils/index.d.cts",
+        "default": "./dist/utils/index.cjs"
+      }
     }
   },
   "directories": {


### PR DESCRIPTION
@web3-name-sdk/core should support both ESM and CommonJS projects.
The build script, "tsup --format esm,cjs --dts --clean” support both of them.

But exports in package.json is listing only ESM files.
So CJS projects can't access .cjs, .cts files, and encounter ERR_REQUIRE_ESM.
   Error [ERR_REQUIRE_ESM]: require() of ES Module XXX/node_modules/@web3-name-sdk/core/dist/index.js from XXX/src/web3name.ts not supported.

This PR fixed package.json of @web3-name-sdk/core to include CJS files in exports list.
