### PR TITLE
refactor: Update RPC URL handling in Web3Name and ContractReader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@bonfida/spl-name-service": "^2.5.1",
+        "@bonfida/spl-name-service": "^3.0.10",
         "@changesets/cli": "^2.26.1",
         "@injectivelabs/networks": "^1.14.6",
         "@injectivelabs/ts-types": "^1.14.6",
@@ -30,7 +30,6 @@
     "node_modules/@apollo/client": {
       "version": "3.13.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -95,22 +94,51 @@
       "license": "Apache-2.0"
     },
     "node_modules/@bonfida/spl-name-service": {
-      "version": "2.5.4",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@bonfida/spl-name-service/-/spl-name-service-3.0.16.tgz",
+      "integrity": "sha512-Y47inKaoGYQ2gxykZsLepc0fNPMLWd5ycGQ6k2FiHvIzlY4trHijc7zr9TyDhB/eI9c3XTy5ItM01Izy5pIZ/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bonfida/sns-records": "0.0.1",
-        "@noble/curves": "^1.3.0",
-        "@scure/base": "^1.1.5",
-        "@solana/buffer-layout": "^4.0.1",
-        "@solana/spl-token": "0.3.9",
+        "@noble/curves": "^1.9.1",
+        "@scure/base": "^1.2.5",
+        "@solana/spl-token": "0.4.6",
         "borsh": "2.0.0",
         "buffer": "^6.0.3",
-        "graphemesplit": "^2.4.4",
-        "ipaddr.js": "^2.1.0",
+        "graphemesplit": "^2.6.0",
+        "ipaddr.js": "^2.2.0",
         "punycode": "^2.3.1"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.87.3"
+        "@solana/web3.js": "^1.98.2"
+      }
+    },
+    "node_modules/@bonfida/spl-name-service/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@bonfida/spl-name-service/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -325,7 +353,6 @@
     "node_modules/@confio/ics23": {
       "version": "0.6.8",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "protobufjs": "^6.8.8"
@@ -334,7 +361,6 @@
     "node_modules/@coral-xyz/anchor": {
       "version": "0.29.0",
       "license": "(MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "@coral-xyz/borsh": "^0.29.0",
         "@noble/hashes": "^1.3.1",
@@ -358,7 +384,6 @@
     "node_modules/@coral-xyz/anchor/node_modules/@coral-xyz/borsh": {
       "version": "0.29.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -373,7 +398,6 @@
     "node_modules/@coral-xyz/anchor/node_modules/base-x": {
       "version": "3.0.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -381,7 +405,6 @@
     "node_modules/@coral-xyz/anchor/node_modules/bs58": {
       "version": "4.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base-x": "^3.0.2"
       }
@@ -389,25 +412,21 @@
     "node_modules/@coral-xyz/anchor/node_modules/cross-fetch": {
       "version": "3.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
     },
     "node_modules/@coral-xyz/anchor/node_modules/eventemitter3": {
       "version": "4.0.7",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@coral-xyz/anchor/node_modules/superstruct": {
       "version": "0.15.5",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@coral-xyz/borsh": {
       "version": "0.28.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -422,7 +441,6 @@
     "node_modules/@cosmjs/amino": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -433,7 +451,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.29.5",
         "@cosmjs/crypto": "^0.29.5",
@@ -451,7 +468,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/amino": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
@@ -462,7 +478,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/crypto": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/encoding": "^0.29.5",
         "@cosmjs/math": "^0.29.5",
@@ -476,7 +491,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/encoding": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -486,7 +500,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/json-rpc": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.29.5",
         "xstream": "^11.14.0"
@@ -495,7 +508,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/math": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -503,7 +515,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/proto-signing": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.29.5",
         "@cosmjs/crypto": "^0.29.5",
@@ -517,7 +528,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/socket": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.29.5",
         "isomorphic-ws": "^4.0.1",
@@ -528,7 +538,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/stargate": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "^0.29.5",
@@ -547,7 +556,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/stream": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "xstream": "^11.14.0"
       }
@@ -555,7 +563,6 @@
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
@@ -571,26 +578,22 @@
     },
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/utils": {
       "version": "0.29.5",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/axios": {
       "version": "0.21.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/bech32": {
       "version": "1.1.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/cosmjs-types": {
       "version": "0.5.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -599,7 +602,6 @@
     "node_modules/@cosmjs/crypto": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/encoding": "^0.32.4",
         "@cosmjs/math": "^0.32.4",
@@ -613,7 +615,6 @@
     "node_modules/@cosmjs/encoding": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -622,13 +623,11 @@
     },
     "node_modules/@cosmjs/encoding/node_modules/bech32": {
       "version": "1.1.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cosmjs/json-rpc": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "xstream": "^11.14.0"
@@ -637,7 +636,6 @@
     "node_modules/@cosmjs/math": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -645,7 +643,6 @@
     "node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -658,7 +655,6 @@
     "node_modules/@cosmjs/socket": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "isomorphic-ws": "^4.0.1",
@@ -669,7 +665,6 @@
     "node_modules/@cosmjs/stargate": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "^0.32.4",
@@ -686,7 +681,6 @@
     "node_modules/@cosmjs/stream": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "xstream": "^11.14.0"
       }
@@ -694,7 +688,6 @@
     "node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -710,8 +703,7 @@
     },
     "node_modules/@cosmjs/utils": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -773,8 +765,7 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ensdomains/buffer/node_modules/@nomiclabs/hardhat-truffle5": {
       "version": "2.0.7",
@@ -804,7 +795,6 @@
     "node_modules/@ensdomains/buffer/node_modules/@scure/base": {
       "version": "1.1.9",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -818,7 +808,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.2.0",
         "@noble/secp256k1": "~1.7.0",
@@ -834,7 +823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.2.0",
         "@scure/base": "~1.1.0"
@@ -842,13 +830,11 @@
     },
     "node_modules/@ensdomains/buffer/node_modules/argparse": {
       "version": "2.0.1",
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/@ensdomains/buffer/node_modules/chokidar": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -861,13 +847,11 @@
     },
     "node_modules/@ensdomains/buffer/node_modules/ci-info": {
       "version": "2.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ensdomains/buffer/node_modules/cliui": {
       "version": "7.0.4",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -877,20 +861,17 @@
     "node_modules/@ensdomains/buffer/node_modules/commander": {
       "version": "8.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/@ensdomains/buffer/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ensdomains/buffer/node_modules/ethereum-cryptography": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.2.0",
         "@noble/secp256k1": "1.7.1",
@@ -901,7 +882,6 @@
     "node_modules/@ensdomains/buffer/node_modules/find-up": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -916,7 +896,6 @@
     "node_modules/@ensdomains/buffer/node_modules/glob": {
       "version": "8.1.0",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1000,7 +979,6 @@
     "node_modules/@ensdomains/buffer/node_modules/js-yaml": {
       "version": "4.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1011,7 +989,6 @@
     "node_modules/@ensdomains/buffer/node_modules/locate-path": {
       "version": "6.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -1025,7 +1002,6 @@
     "node_modules/@ensdomains/buffer/node_modules/mocha": {
       "version": "10.8.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -1059,7 +1035,6 @@
     "node_modules/@ensdomains/buffer/node_modules/mocha/node_modules/chokidar": {
       "version": "3.6.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1082,7 +1057,6 @@
     "node_modules/@ensdomains/buffer/node_modules/mocha/node_modules/readdirp": {
       "version": "3.6.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -1093,7 +1067,6 @@
     "node_modules/@ensdomains/buffer/node_modules/p-limit": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -1107,7 +1080,6 @@
     "node_modules/@ensdomains/buffer/node_modules/p-locate": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -1121,7 +1093,6 @@
     "node_modules/@ensdomains/buffer/node_modules/p-map": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -1135,7 +1106,6 @@
     "node_modules/@ensdomains/buffer/node_modules/readdirp": {
       "version": "4.1.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -1147,7 +1117,6 @@
     "node_modules/@ensdomains/buffer/node_modules/resolve": {
       "version": "1.17.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-parse": "^1.0.6"
       },
@@ -1158,7 +1127,6 @@
     "node_modules/@ensdomains/buffer/node_modules/semver": {
       "version": "6.3.1",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1166,7 +1134,6 @@
     "node_modules/@ensdomains/buffer/node_modules/solc": {
       "version": "0.8.26",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "command-exists": "^1.2.8",
         "commander": "^8.1.0",
@@ -1186,7 +1153,6 @@
     "node_modules/@ensdomains/buffer/node_modules/solc/node_modules/semver": {
       "version": "5.7.2",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -1194,7 +1160,6 @@
     "node_modules/@ensdomains/buffer/node_modules/string-width": {
       "version": "4.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1207,7 +1172,6 @@
     "node_modules/@ensdomains/buffer/node_modules/undici": {
       "version": "5.29.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -1218,7 +1182,6 @@
     "node_modules/@ensdomains/buffer/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1234,7 +1197,6 @@
     "node_modules/@ensdomains/buffer/node_modules/yargs": {
       "version": "16.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -1251,7 +1213,6 @@
     "node_modules/@ensdomains/buffer/node_modules/yargs-parser": {
       "version": "20.2.9",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2078,7 +2039,6 @@
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2086,7 +2046,6 @@
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
@@ -2094,7 +2053,6 @@
     "node_modules/@injectivelabs/abacus-proto-ts": {
       "version": "1.13.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2105,21 +2063,18 @@
     "node_modules/@injectivelabs/abacus-proto-ts/node_modules/@types/node": {
       "version": "22.13.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@injectivelabs/abacus-proto-ts/node_modules/long": {
       "version": "5.3.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/abacus-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2141,7 +2096,6 @@
     "node_modules/@injectivelabs/core-proto-ts": {
       "version": "1.13.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2152,21 +2106,18 @@
     "node_modules/@injectivelabs/core-proto-ts/node_modules/@types/node": {
       "version": "22.13.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@injectivelabs/core-proto-ts/node_modules/long": {
       "version": "5.3.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/core-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2198,6 +2149,7 @@
     "node_modules/@injectivelabs/grpc-web": {
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -2208,7 +2160,6 @@
     "node_modules/@injectivelabs/grpc-web-node-http-transport": {
       "version": "0.0.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
@@ -2216,7 +2167,6 @@
     "node_modules/@injectivelabs/grpc-web-react-native-transport": {
       "version": "0.0.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
@@ -2224,7 +2174,6 @@
     "node_modules/@injectivelabs/indexer-proto-ts": {
       "version": "1.13.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2235,21 +2184,18 @@
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/@types/node": {
       "version": "22.13.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/long": {
       "version": "5.3.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2271,7 +2217,6 @@
     "node_modules/@injectivelabs/mito-proto-ts": {
       "version": "1.13.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2282,21 +2227,18 @@
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/@types/node": {
       "version": "22.13.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/long": {
       "version": "5.3.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2328,7 +2270,6 @@
     "node_modules/@injectivelabs/olp-proto-ts": {
       "version": "1.13.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -2339,21 +2280,18 @@
     "node_modules/@injectivelabs/olp-proto-ts/node_modules/@types/node": {
       "version": "22.13.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts/node_modules/long": {
       "version": "5.3.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/olp-proto-ts/node_modules/protobufjs": {
       "version": "7.4.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2375,7 +2313,6 @@
     "node_modules/@injectivelabs/sdk-ts": {
       "version": "1.14.41",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@apollo/client": "^3.11.10",
         "@cosmjs/amino": "^0.32.3",
@@ -2415,13 +2352,11 @@
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@noble/hashes": {
       "version": "1.3.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -2432,15 +2367,13 @@
     "node_modules/@injectivelabs/sdk-ts/node_modules/@types/node": {
       "version": "22.7.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/ethers": {
       "version": "6.13.5",
@@ -2455,7 +2388,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -2472,7 +2404,6 @@
     "node_modules/@injectivelabs/sdk-ts/node_modules/ethers/node_modules/@noble/curves": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -2482,18 +2413,15 @@
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/tslib": {
       "version": "2.7.0",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/undici-types": {
       "version": "6.19.8",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/ws": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2513,7 +2441,6 @@
     "node_modules/@injectivelabs/test-utils": {
       "version": "1.14.41",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.41",
         "@injectivelabs/networks": "^1.14.41",
@@ -2529,6 +2456,7 @@
     "node_modules/@injectivelabs/ts-types": {
       "version": "1.14.41",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "shx": "^0.3.2"
       }
@@ -2643,7 +2571,6 @@
     "node_modules/@keplr-wallet/types": {
       "version": "0.11.64",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "axios": "^0.27.2",
         "long": "^4.0.0"
@@ -2652,7 +2579,6 @@
     "node_modules/@keplr-wallet/types/node_modules/axios": {
       "version": "0.27.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -2720,7 +2646,6 @@
     "node_modules/@metamask/eth-sig-util": {
       "version": "4.0.1",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "ethereumjs-abi": "^0.6.8",
         "ethereumjs-util": "^6.2.1",
@@ -2735,20 +2660,17 @@
     "node_modules/@metamask/eth-sig-util/node_modules/@types/bn.js": {
       "version": "4.11.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -2790,8 +2712,7 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2828,7 +2749,6 @@
     "node_modules/@nomicfoundation/edr": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/edr-darwin-arm64": "0.8.0",
         "@nomicfoundation/edr-darwin-x64": "0.8.0",
@@ -2845,7 +2765,6 @@
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2853,7 +2772,6 @@
     "node_modules/@nomicfoundation/edr-darwin-x64": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2861,7 +2779,6 @@
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2869,7 +2786,6 @@
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2877,7 +2793,6 @@
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2885,7 +2800,6 @@
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2893,7 +2807,6 @@
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
       "version": "0.8.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 18"
       }
@@ -2901,7 +2814,6 @@
     "node_modules/@nomicfoundation/ethereumjs-common": {
       "version": "4.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/ethereumjs-util": "9.0.4"
       }
@@ -2909,7 +2821,6 @@
     "node_modules/@nomicfoundation/ethereumjs-rlp": {
       "version": "5.0.4",
       "license": "MPL-2.0",
-      "peer": true,
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -2920,7 +2831,6 @@
     "node_modules/@nomicfoundation/ethereumjs-tx": {
       "version": "5.0.4",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/ethereumjs-common": "4.0.4",
         "@nomicfoundation/ethereumjs-rlp": "5.0.4",
@@ -2942,7 +2852,6 @@
     "node_modules/@nomicfoundation/ethereumjs-util": {
       "version": "9.0.4",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/ethereumjs-rlp": "5.0.4",
         "ethereum-cryptography": "0.1.3"
@@ -2962,7 +2871,6 @@
     "node_modules/@nomicfoundation/solidity-analyzer": {
       "version": "0.1.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       },
@@ -2980,7 +2888,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2989,7 +2896,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2998,7 +2904,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3007,7 +2912,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3016,7 +2920,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3025,7 +2928,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3034,7 +2936,6 @@
       "version": "0.1.2",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3131,7 +3032,6 @@
     "node_modules/@osmonauts/helpers": {
       "version": "0.6.0",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.9",
         "@cosmjs/amino": "0.28.13",
@@ -3146,7 +3046,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/amino": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "0.28.13",
         "@cosmjs/encoding": "0.28.13",
@@ -3157,7 +3056,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/crypto": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/encoding": "0.28.13",
         "@cosmjs/math": "0.28.13",
@@ -3171,7 +3069,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/encoding": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -3181,7 +3078,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/json-rpc": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "0.28.13",
         "xstream": "^11.14.0"
@@ -3190,7 +3086,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/math": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -3198,7 +3093,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/proto-signing": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "0.28.13",
         "@cosmjs/crypto": "0.28.13",
@@ -3212,7 +3106,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/proto-signing/node_modules/cosmjs-types": {
       "version": "0.4.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -3220,13 +3113,11 @@
     },
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/proto-signing/node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/socket": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "0.28.13",
         "isomorphic-ws": "^4.0.1",
@@ -3237,7 +3128,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/stargate": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "0.28.13",
@@ -3256,7 +3146,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/stargate/node_modules/cosmjs-types": {
       "version": "0.4.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -3264,13 +3153,11 @@
     },
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/stargate/node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/stream": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "xstream": "^11.14.0"
       }
@@ -3278,7 +3165,6 @@
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.28.13",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "0.28.13",
         "@cosmjs/encoding": "0.28.13",
@@ -3294,26 +3180,22 @@
     },
     "node_modules/@osmonauts/helpers/node_modules/@cosmjs/utils": {
       "version": "0.28.13",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@osmonauts/helpers/node_modules/axios": {
       "version": "0.21.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@osmonauts/helpers/node_modules/bech32": {
       "version": "1.1.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@osmonauts/helpers/node_modules/cosmjs-types": {
       "version": "0.5.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -3321,18 +3203,15 @@
     },
     "node_modules/@osmonauts/helpers/node_modules/cosmjs-types/node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@osmonauts/helpers/node_modules/long": {
       "version": "5.3.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@osmonauts/lcd": {
       "version": "0.8.0",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.19.0",
         "axios": "0.27.2"
@@ -3341,7 +3220,6 @@
     "node_modules/@osmonauts/lcd/node_modules/axios": {
       "version": "0.27.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -3352,35 +3230,29 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -3388,33 +3260,27 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@pythnetwork/client": {
       "version": "2.22.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",
         "@coral-xyz/borsh": "^0.28.0",
@@ -3425,7 +3291,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3434,7 +3302,6 @@
     "node_modules/@scure/bip32": {
       "version": "1.6.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.8.1",
         "@noble/hashes": "~1.7.1",
@@ -3447,7 +3314,6 @@
     "node_modules/@scure/bip39": {
       "version": "1.5.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.7.1",
         "@scure/base": "~1.2.4"
@@ -3488,7 +3354,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/amino": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
@@ -3499,7 +3364,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/crypto": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/encoding": "^0.29.5",
         "@cosmjs/math": "^0.29.5",
@@ -3513,7 +3377,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/encoding": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -3522,13 +3385,11 @@
     },
     "node_modules/@sei-js/core/node_modules/@cosmjs/encoding/node_modules/bech32": {
       "version": "1.1.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sei-js/core/node_modules/@cosmjs/json-rpc": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.29.5",
         "xstream": "^11.14.0"
@@ -3537,7 +3398,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/math": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -3545,7 +3405,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/proto-signing": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.29.5",
         "@cosmjs/crypto": "^0.29.5",
@@ -3559,7 +3418,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/socket": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.29.5",
         "isomorphic-ws": "^4.0.1",
@@ -3570,7 +3428,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/stargate": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "^0.29.5",
@@ -3589,7 +3446,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/stream": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "xstream": "^11.14.0"
       }
@@ -3597,7 +3453,6 @@
     "node_modules/@sei-js/core/node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
@@ -3613,13 +3468,11 @@
     },
     "node_modules/@sei-js/core/node_modules/@cosmjs/utils": {
       "version": "0.29.5",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@sei-js/core/node_modules/axios": {
       "version": "0.21.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -3627,7 +3480,6 @@
     "node_modules/@sei-js/core/node_modules/cosmjs-types": {
       "version": "0.5.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -3636,7 +3488,6 @@
     "node_modules/@sei-js/proto": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.9",
         "@cosmjs/amino": "^0.29.5",
@@ -3652,7 +3503,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/amino": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
@@ -3663,7 +3513,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/crypto": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/encoding": "^0.29.5",
         "@cosmjs/math": "^0.29.5",
@@ -3677,7 +3526,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/encoding": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -3687,7 +3535,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/json-rpc": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.29.5",
         "xstream": "^11.14.0"
@@ -3696,7 +3543,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/math": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0"
       }
@@ -3704,7 +3550,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/proto-signing": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.29.5",
         "@cosmjs/crypto": "^0.29.5",
@@ -3718,7 +3563,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/socket": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/stream": "^0.29.5",
         "isomorphic-ws": "^4.0.1",
@@ -3729,7 +3573,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/stargate": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "^0.29.5",
@@ -3748,7 +3591,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/stream": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "xstream": "^11.14.0"
       }
@@ -3756,7 +3598,6 @@
     "node_modules/@sei-js/proto/node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.29.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.29.5",
         "@cosmjs/encoding": "^0.29.5",
@@ -3772,26 +3613,22 @@
     },
     "node_modules/@sei-js/proto/node_modules/@cosmjs/utils": {
       "version": "0.29.5",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@sei-js/proto/node_modules/axios": {
       "version": "0.21.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@sei-js/proto/node_modules/bech32": {
       "version": "1.1.4",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sei-js/proto/node_modules/cosmjs-types": {
       "version": "0.5.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "~6.11.2"
@@ -3800,7 +3637,6 @@
     "node_modules/@sentry/core": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sentry/hub": "5.30.0",
         "@sentry/minimal": "5.30.0",
@@ -3814,13 +3650,11 @@
     },
     "node_modules/@sentry/core/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@sentry/hub": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sentry/types": "5.30.0",
         "@sentry/utils": "5.30.0",
@@ -3832,13 +3666,11 @@
     },
     "node_modules/@sentry/hub/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@sentry/minimal": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sentry/hub": "5.30.0",
         "@sentry/types": "5.30.0",
@@ -3850,13 +3682,11 @@
     },
     "node_modules/@sentry/minimal/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@sentry/node": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sentry/core": "5.30.0",
         "@sentry/hub": "5.30.0",
@@ -3875,20 +3705,17 @@
     "node_modules/@sentry/node/node_modules/cookie": {
       "version": "0.4.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/@sentry/node/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@sentry/tracing": {
       "version": "5.30.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sentry/hub": "5.30.0",
         "@sentry/minimal": "5.30.0",
@@ -3902,13 +3729,11 @@
     },
     "node_modules/@sentry/tracing/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@sentry/types": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3916,7 +3741,6 @@
     "node_modules/@sentry/utils": {
       "version": "5.30.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sentry/types": "5.30.0",
         "tslib": "^1.9.3"
@@ -3927,8 +3751,7 @@
     },
     "node_modules/@sentry/utils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/@siddomains/address-encoder": {
       "version": "0.0.4",
@@ -3968,6 +3791,7 @@
     "node_modules/@siddomains/injective-sidjs": {
       "version": "0.0.2-beta",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.4.4",
         "@ensdomains/ens-validation": "^0.1.0",
@@ -4058,31 +3882,305 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@solana/codecs": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-preview.2.tgz",
+      "integrity": "sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-data-structures": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/codecs-strings": "2.0.0-preview.2",
+        "@solana/options": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-preview.2.tgz",
+      "integrity": "sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-preview.2.tgz",
+      "integrity": "sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-preview.2.tgz",
+      "integrity": "sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-preview.2.tgz",
+      "integrity": "sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-preview.2.tgz",
+      "integrity": "sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.js"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-preview.2.tgz",
+      "integrity": "sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2"
+      }
+    },
     "node_modules/@solana/spl-token": {
-      "version": "0.3.9",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.6.tgz",
+      "integrity": "sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.4",
+        "@solana/spl-token-metadata": "^0.1.4",
         "buffer": "^6.0.3"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.47.4"
+        "@solana/web3.js": "^1.91.6"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.4.tgz",
+      "integrity": "sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-preview.2",
+        "@solana/spl-type-length-value": "0.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.91.6"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-type-length-value": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-type-length-value/-/spl-type-length-value-0.1.0.tgz",
+      "integrity": "sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.98.0",
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
         "@noble/hashes": "^1.4.0",
         "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
         "agentkeepalive": "^4.5.0",
-        "bigint-buffer": "^1.1.5",
         "bn.js": "^5.2.1",
         "borsh": "^0.7.0",
         "bs58": "^4.0.1",
@@ -4092,6 +4190,56 @@
         "node-fetch": "^2.7.0",
         "rpc-websockets": "^9.0.2",
         "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
       }
     },
     "node_modules/@solana/web3.js/node_modules/base-x": {
@@ -4115,6 +4263,27 @@
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/commander": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@swc/helpers": {
@@ -4907,13 +5076,11 @@
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -4922,7 +5089,8 @@
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.2",
@@ -4967,7 +5135,6 @@
     "node_modules/@wry/caches": {
       "version": "1.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4978,7 +5145,6 @@
     "node_modules/@wry/context": {
       "version": "0.7.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4989,7 +5155,6 @@
     "node_modules/@wry/equality": {
       "version": "0.5.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5000,7 +5165,6 @@
     "node_modules/@wry/trie": {
       "version": "0.5.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5011,7 +5175,6 @@
     "node_modules/abitype": {
       "version": "1.0.8",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -5068,7 +5231,6 @@
     "node_modules/adm-zip": {
       "version": "0.4.16",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.3.0"
       }
@@ -5080,7 +5242,6 @@
     "node_modules/agent-base": {
       "version": "6.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -5101,7 +5262,6 @@
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -5127,20 +5287,17 @@
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.1.0"
       }
     },
     "node_modules/ansi-align/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ansi-align/node_modules/string-width": {
       "version": "4.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5160,7 +5317,6 @@
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -5174,7 +5330,6 @@
     "node_modules/ansi-escapes/node_modules/type-fest": {
       "version": "0.21.3",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5357,7 +5512,6 @@
     "node_modules/bech32-buffer": {
       "version": "0.2.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5429,7 +5583,6 @@
     "node_modules/bip39": {
       "version": "3.1.0",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0"
       }
@@ -5490,7 +5643,6 @@
     "node_modules/boxen": {
       "version": "5.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-align": "^3.0.0",
         "camelcase": "^6.2.0",
@@ -5510,13 +5662,11 @@
     },
     "node_modules/boxen/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/boxen/node_modules/string-width": {
       "version": "4.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5529,7 +5679,6 @@
     "node_modules/boxen/node_modules/type-fest": {
       "version": "0.20.2",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5540,7 +5689,6 @@
     "node_modules/boxen/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5580,8 +5728,7 @@
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -5654,7 +5801,6 @@
     "node_modules/buffer-layout": {
       "version": "1.2.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.5"
       }
@@ -5671,6 +5817,7 @@
       "version": "4.0.9",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -5813,7 +5960,6 @@
     "node_modules/camelcase": {
       "version": "6.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5839,6 +5985,7 @@
     "node_modules/chai": {
       "version": "4.5.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -5866,7 +6013,6 @@
     "node_modules/chalk": {
       "version": "4.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5881,7 +6027,6 @@
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6095,7 +6240,6 @@
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6103,7 +6247,6 @@
     "node_modules/cli-boxes": {
       "version": "2.2.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -6115,7 +6258,6 @@
       "version": "8.0.1",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -6128,14 +6270,12 @@
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6149,7 +6289,6 @@
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6212,8 +6351,7 @@
     },
     "node_modules/command-exists": {
       "version": "1.2.9",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -6303,8 +6441,7 @@
     },
     "node_modules/cosmjs-types": {
       "version": "0.9.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -6394,7 +6531,6 @@
     "node_modules/crypto-hash": {
       "version": "1.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6404,8 +6540,7 @@
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.1.0",
@@ -6474,7 +6609,6 @@
     "node_modules/decamelize": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6547,7 +6681,6 @@
     "node_modules/define-properties": {
       "version": "1.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -6603,7 +6736,6 @@
     "node_modules/diff": {
       "version": "5.2.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6797,7 +6929,6 @@
     "node_modules/env-paths": {
       "version": "2.2.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6896,6 +7027,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6930,7 +7062,6 @@
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6942,7 +7073,6 @@
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7074,7 +7204,6 @@
     "node_modules/ethereumjs-abi": {
       "version": "0.6.8",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -7083,20 +7212,17 @@
     "node_modules/ethereumjs-abi/node_modules/@types/bn.js": {
       "version": "4.11.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/ethereumjs-abi/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "6.2.1",
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -7134,6 +7260,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/abstract-provider": "5.8.0",
@@ -7186,7 +7313,6 @@
     "node_modules/ethjs-util": {
       "version": "0.1.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -7381,6 +7507,13 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "dev": true,
@@ -7445,7 +7578,6 @@
     "node_modules/flat": {
       "version": "5.0.2",
       "license": "BSD-3-Clause",
-      "peer": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -7529,8 +7661,7 @@
     },
     "node_modules/fp-ts": {
       "version": "1.19.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -7591,7 +7722,6 @@
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -7707,7 +7837,6 @@
     "node_modules/globalthis": {
       "version": "1.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -7801,7 +7930,6 @@
     "node_modules/graphql-tag": {
       "version": "2.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -7833,7 +7961,6 @@
     "node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7908,7 +8035,6 @@
     "node_modules/he": {
       "version": "1.2.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "he": "bin/he"
       }
@@ -7955,7 +8081,6 @@
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -8034,7 +8159,6 @@
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -8135,13 +8259,11 @@
     },
     "node_modules/immutable": {
       "version": "4.3.7",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8175,7 +8297,6 @@
     "node_modules/io-ts": {
       "version": "1.10.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fp-ts": "^1.0.0"
       }
@@ -8311,7 +8432,6 @@
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8374,7 +8494,6 @@
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8422,7 +8541,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -8499,8 +8617,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -8533,7 +8650,6 @@
     "node_modules/json-stream-stringify": {
       "version": "3.1.6",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=7.10.1"
       }
@@ -8611,7 +8727,6 @@
     "node_modules/keccak256": {
       "version": "1.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
@@ -8644,18 +8759,15 @@
     },
     "node_modules/libsodium": {
       "version": "0.7.15",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/libsodium-sumo": {
       "version": "0.7.15",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/libsodium-wrappers": {
       "version": "0.7.15",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "libsodium": "^0.7.15"
       }
@@ -8663,7 +8775,6 @@
     "node_modules/libsodium-wrappers-sumo": {
       "version": "0.7.15",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "libsodium-sumo": "^0.7.15"
       }
@@ -8763,7 +8874,6 @@
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -8777,13 +8887,11 @@
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8828,8 +8936,7 @@
     },
     "node_modules/lru_map": {
       "version": "0.3.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -8982,7 +9089,6 @@
     "node_modules/minimatch": {
       "version": "5.1.6",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -9043,7 +9149,6 @@
     "node_modules/mnemonist": {
       "version": "0.38.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "obliterator": "^2.0.0"
       }
@@ -9052,7 +9157,6 @@
       "version": "11.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -9086,14 +9190,12 @@
     "node_modules/mocha/node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
-      "license": "Python-2.0",
-      "peer": true
+      "license": "Python-2.0"
     },
     "node_modules/mocha/node_modules/find-up": {
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -9109,7 +9211,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -9121,7 +9222,6 @@
       "version": "6.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -9136,7 +9236,6 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -9151,7 +9250,6 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -9169,7 +9267,6 @@
     "node_modules/moment": {
       "version": "2.30.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -9456,15 +9553,13 @@
     "node_modules/object-keys": {
       "version": "1.1.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/obliterator": {
       "version": "2.0.5",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/oboe": {
       "version": "2.1.5",
@@ -9507,7 +9602,6 @@
     "node_modules/optimism": {
       "version": "0.18.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wry/caches": "^1.0.0",
         "@wry/context": "^0.7.0",
@@ -9546,7 +9640,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.1",
         "@noble/curves": "^1.6.0",
@@ -9639,8 +9732,7 @@
     },
     "node_modules/pako": {
       "version": "2.1.0",
-      "license": "(MIT AND Zlib)",
-      "peer": true
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "2.1.1",
@@ -9894,7 +9986,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9905,7 +9996,6 @@
       "version": "6.11.4",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9929,7 +10019,6 @@
     "node_modules/protobufjs/node_modules/@types/node": {
       "version": "22.13.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -10093,8 +10182,7 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/read-pkg": {
       "version": "1.1.0",
@@ -10198,8 +10286,7 @@
     },
     "node_modules/readonly-date": {
       "version": "1.0.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
@@ -10217,7 +10304,6 @@
     "node_modules/rehackt": {
       "version": "0.1.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "*"
@@ -10517,7 +10603,6 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10652,7 +10737,6 @@
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -11184,7 +11268,6 @@
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.7.1"
       },
@@ -11195,7 +11278,6 @@
     "node_modules/stacktrace-parser/node_modules/type-fest": {
       "version": "0.7.1",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11344,7 +11426,6 @@
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -11391,7 +11472,6 @@
     "node_modules/supports-color": {
       "version": "8.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11540,7 +11620,6 @@
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -11623,7 +11702,6 @@
     "node_modules/tinyglobby": {
       "version": "0.2.12",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fdir": "^6.4.3",
         "picomatch": "^4.0.2"
@@ -11638,7 +11716,6 @@
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.4.3",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -11707,8 +11784,7 @@
     },
     "node_modules/toml": {
       "version": "3.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
@@ -11741,7 +11817,6 @@
     "node_modules/ts-invariant": {
       "version": "0.10.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -11773,6 +11848,7 @@
       "version": "7.0.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "arrify": "^1.0.0",
         "buffer-from": "^1.1.0",
@@ -11816,8 +11892,7 @@
     },
     "node_modules/tsort": {
       "version": "0.0.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -11831,13 +11906,11 @@
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
-      "license": "Unlicense",
-      "peer": true
+      "license": "Unlicense"
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
-      "license": "Unlicense",
-      "peer": true
+      "license": "Unlicense"
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -11880,8 +11953,8 @@
     },
     "node_modules/typescript": {
       "version": "5.8.2",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11907,8 +11980,7 @@
     },
     "node_modules/undici-types": {
       "version": "6.20.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-trie": {
       "version": "2.0.0",
@@ -11962,6 +12034,7 @@
       "version": "5.0.10",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -12047,7 +12120,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.8.1",
         "@noble/hashes": "1.7.1",
@@ -12070,7 +12142,6 @@
     "node_modules/viem/node_modules/ws": {
       "version": "8.18.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12091,6 +12162,7 @@
       "version": "1.10.4",
       "hasInstallScript": true,
       "license": "LGPL-3.0",
+      "peer": true,
       "dependencies": {
         "web3-bzz": "1.10.4",
         "web3-core": "1.10.4",
@@ -12136,6 +12208,7 @@
     "node_modules/web3-core-helpers": {
       "version": "1.10.4",
       "license": "LGPL-3.0",
+      "peer": true,
       "dependencies": {
         "web3-eth-iban": "1.10.4",
         "web3-utils": "1.10.4"
@@ -12161,6 +12234,7 @@
     "node_modules/web3-core-promievent": {
       "version": "1.10.4",
       "license": "LGPL-3.0",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "4.0.4"
       },
@@ -12225,6 +12299,7 @@
     "node_modules/web3-eth-abi": {
       "version": "1.10.4",
       "license": "LGPL-3.0",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.6.3",
         "web3-utils": "1.10.4"
@@ -12405,6 +12480,7 @@
     "node_modules/web3-utils": {
       "version": "1.10.4",
       "license": "LGPL-3.0",
+      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "bn.js": "^5.2.1",
@@ -12584,7 +12660,6 @@
     "node_modules/widest-line": {
       "version": "3.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.0.0"
       },
@@ -12594,13 +12669,11 @@
     },
     "node_modules/widest-line/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/widest-line/node_modules/string-width": {
       "version": "4.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12622,8 +12695,7 @@
     },
     "node_modules/workerpool": {
       "version": "6.5.1",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -12719,6 +12791,7 @@
     "node_modules/ws": {
       "version": "7.5.10",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -12775,7 +12848,6 @@
     "node_modules/xstream": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "globalthis": "^1.0.1",
         "symbol-observable": "^2.0.3"
@@ -12784,7 +12856,6 @@
     "node_modules/xstream/node_modules/symbol-observable": {
       "version": "2.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -12799,7 +12870,6 @@
     "node_modules/y18n": {
       "version": "5.0.8",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -12830,7 +12900,6 @@
       "version": "17.7.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -12848,7 +12917,6 @@
       "version": "21.1.1",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12856,7 +12924,6 @@
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
@@ -12870,14 +12937,12 @@
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12898,7 +12963,6 @@
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12908,20 +12972,18 @@
     },
     "node_modules/zen-observable": {
       "version": "0.8.15",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "zen-observable": "0.8.15"
       }
     },
     "packages/core": {
       "name": "@web3-name-sdk/core",
-      "version": "0.3.5-beta.2",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.0",
@@ -12938,7 +13000,7 @@
         "tsup": "^7.1.0"
       },
       "peerDependencies": {
-        "@bonfida/spl-name-service": "^2.5.1",
+        "@bonfida/spl-name-service": "^3.0.10",
         "@sei-js/core": "^3.1.0",
         "@siddomains/injective-sidjs": "0.0.2-beta",
         "@siddomains/sei-sidjs": "^0.0.4",
@@ -13011,6 +13073,7 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -13216,7 +13279,6 @@
     "packages/register/node_modules/@solana/spl-token": {
       "version": "0.3.7",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -13270,7 +13332,6 @@
     "packages/register/node_modules/base-x": {
       "version": "3.0.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -13278,7 +13339,6 @@
     "packages/register/node_modules/borsh": {
       "version": "0.7.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
@@ -13288,7 +13348,6 @@
     "packages/register/node_modules/bs58": {
       "version": "4.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base-x": "^3.0.2"
       }
@@ -13298,7 +13357,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -13367,50 +13425,6 @@
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "packages/register/node_modules/ts-node": {
-      "version": "10.9.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
       }
     },
     "packages/register/node_modules/tsup": {
@@ -13503,6 +13517,7 @@
     "packages/register/node_modules/ws": {
       "version": "8.13.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13524,7 +13539,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/packages/core/src/tlds/web3name/index.ts
+++ b/packages/core/src/tlds/web3name/index.ts
@@ -515,20 +515,13 @@ export class Web3Name {
 
       try {
         if (tld === TLD.ENS) {
-          const data = await fetch('https://spaceapi.prd.space.id/rpc/1')
-          const rpcUrlConfig = await data.json()
           const tldInfoList = await this.contractReader.getTldInfo([tld])
           const publicClient = createPublicClient({
             chain: getChainFromId(Number(tldInfoList[0].chainId)),
-            transport: http(
-              rpcUrl ||
-                'https://rpc.ankr.com/eth/01048c161385f5499bbe8f88cf68ce3d713c908be21217de37266424d49fefd7' ||
-                rpcUrlConfig.url,
-              {
-                timeout: timeout,
-                fetchOptions: { signal },
-              }
-            ),
+            transport: http(rpcUrl || this.contractReader.getRpcUrl(), {
+              timeout: timeout,
+              fetchOptions: { signal },
+            }),
           })
           return await publicClient.getEnsAddress({
             name: normalizedDomain,

--- a/packages/core/src/utils/contract.ts
+++ b/packages/core/src/utils/contract.ts
@@ -37,7 +37,6 @@ export class ContractReader {
     if (!rpcUrl) {
       this.initRpcUrl().then((url) => {
         this.rpcUrl = url
-        console.log('Updated RPC URL:', this.rpcUrl)
       })
     }
     this.timeout = timeout

--- a/packages/core/src/utils/contract.ts
+++ b/packages/core/src/utils/contract.ts
@@ -23,6 +23,9 @@ import { CONTRACTS } from '../constants/contracts'
 import { TldInfo } from '../types/tldInfo'
 import { createCustomClient, getBaseContractFromChainId } from './common'
 
+const DEFAULT_RPC_URL = 'https://ethereum-rpc.publicnode.com'
+const RPC_API_URL = 'https://spaceapi.prd.space.id/rpc/1'
+
 export class ContractReader {
   private isDev: boolean
   private rpcUrl?: string
@@ -30,7 +33,7 @@ export class ContractReader {
 
   constructor(isDev: boolean, rpcUrl?: string, timeout?: number) {
     this.isDev = isDev
-    this.rpcUrl = rpcUrl || 'https://rpc.ankr.com/eth/01048c161385f5499bbe8f88cf68ce3d713c908be21217de37266424d49fefd7'
+    this.rpcUrl = rpcUrl || DEFAULT_RPC_URL
     if (!rpcUrl) {
       this.initRpcUrl().then((url) => {
         this.rpcUrl = url
@@ -42,17 +45,26 @@ export class ContractReader {
 
   private async initRpcUrl(): Promise<string> {
     try {
-      const response = await fetch('https://spaceapi.prd.space.id/rpc/1')
+      const response = await fetch(RPC_API_URL)
       const data = await response.json()
-      return data.url ?? 'https://rpc.ankr.com/eth/01048c161385f5499bbe8f88cf68ce3d713c908be21217de37266424d49fefd7'
+      return data.url ?? DEFAULT_RPC_URL
     } catch (error) {
       console.error('Error fetching RPC URL:', error)
-      return 'https://rpc.ankr.com/eth/01048c161385f5499bbe8f88cf68ce3d713c908be21217de37266424d49fefd7'
+      return DEFAULT_RPC_URL
     }
   }
 
   getTimeout() {
     return this.timeout
+  }
+
+  /**
+   * Get current RPC URL
+   * If user didn't provide one, it may be dynamically fetched from API
+   * @returns Current RPC URL
+   */
+  getRpcUrl(): string {
+    return this.rpcUrl || DEFAULT_RPC_URL
   }
 
   async withTimeout<T>(operation: (signal: AbortSignal) => Promise<T>, timeoutMs?: number): Promise<T> {

--- a/packages/core/tests/sid.spec.ts
+++ b/packages/core/tests/sid.spec.ts
@@ -121,4 +121,30 @@ describe('SID Name resolving', () => {
 
     expect(domainName).to.be.not.null
   }).timeout(10000)
+
+  it('it should properly resolve ENS address with custom RPC', async () => {
+    const sid = createWeb3Name()
+
+    const domainName = await sid.getAddress('olddomain.eth', {
+      rpcUrl: 'https://ethereum-rpc.publicnode.com',
+    })
+
+    expect(domainName).to.be.eq('0xd03D02A3490218123Da4b4994538Af9EA2Ee5D05')
+  }).timeout(10000)
+
+  it('it should properly resolve ENS address without custom RPC (use dynamic RPC URL)', async () => {
+    const sid = createWeb3Name()
+
+    const domainName = await sid.getAddress('olddomain.eth')
+
+    expect(domainName).to.be.eq('0xd03D02A3490218123Da4b4994538Af9EA2Ee5D05')
+  }).timeout(10000)
+
+  it('it should properly use constructor rpcUrl for ENS', async () => {
+    const sid = createWeb3Name({ rpcUrl: 'https://ethereum-rpc.publicnode.com' })
+
+    const domainName = await sid.getAddress('olddomain.eth')
+
+    expect(domainName).to.be.eq('0xd03D02A3490218123Da4b4994538Af9EA2Ee5D05')
+  }).timeout(10000)
 })


### PR DESCRIPTION
- Removed hardcoded RPC URL in Web3Name and replaced it with a dynamic RPC URL fetched from ContractReader.
- Introduced DEFAULT_RPC_URL and RPC_API_URL constants for better maintainability.
- Enhanced ContractReader to provide a method for retrieving the current RPC URL.
- Added tests to ensure proper resolution of ENS addresses with both custom and dynamic RPC URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved ENS name resolution to use a centralized default RPC and reliably fall back when remote lookup fails.
  * Exposed the current RPC URL via a public accessor and removed an unnecessary logging side-effect.

* **Tests**
  * Added ENS resolution tests covering custom RPC, dynamic RPC discovery, and constructor-supplied RPC scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->